### PR TITLE
Update AphlictClientServer to support ws2 or ws3

### DIFF
--- a/support/aphlict/server/lib/AphlictClientServer.js
+++ b/support/aphlict/server/lib/AphlictClientServer.js
@@ -76,8 +76,14 @@ JX.install('AphlictClientServer', {
       var server = this._server.listen.apply(this._server, arguments);
       var wss = new WebSocket.Server({server: server});
 
-      wss.on('connection', function(ws) {
-        var path = url.parse(ws.upgradeReq.url).pathname;
+      // This function checks for upgradeReq which is only available in
+      // ws2 by default, not ws3. See T12755 for more information.
+      wss.on('connection', function(ws, request) {
+        if ('upgradeReq' in ws) {
+          request = ws.upgradeReq;
+        }
+
+        var path = url.parse(request.url).pathname;
         var instance = self._parseInstanceFromPath(path);
 
         var listener = self.getListenerList(instance).addListener(ws);


### PR DESCRIPTION
I'm not sure if endlessm-test is the right branch to target PRs for in our repo.

Summary: This lets us support either ws2 or ws3. Fixes T12755

Test Plan: Update server to version 3, send message, watch debug log. Downgrade to 2.x, send messages, watch debug log. Everything seems OK

Reviewers: epriestley

Reviewed By: epriestley

Subscribers: Korvin

Maniphest Tasks: T12755

Differential Revision: https://secure.phabricator.com/D18411