### PR TITLE
Fix a bad method call signature throwing exceptions in newer Node

### DIFF
--- a/resources/celerity/map.php
+++ b/resources/celerity/map.php
@@ -217,7 +217,7 @@ return array(
     'rsrc/externals/javelin/core/__tests__/stratcom.js' => '88bf7313',
     'rsrc/externals/javelin/core/__tests__/util.js' => 'e251703d',
     'rsrc/externals/javelin/core/init.js' => '3010e992',
-    'rsrc/externals/javelin/core/init_node.js' => 'c234aded',
+    'rsrc/externals/javelin/core/init_node.js' => 'f7732951',
     'rsrc/externals/javelin/core/install.js' => '05270951',
     'rsrc/externals/javelin/core/util.js' => '93cc50d6',
     'rsrc/externals/javelin/docs/Base.js' => '74676256',

--- a/src/view/control/AphrontTableView.php
+++ b/src/view/control/AphrontTableView.php
@@ -4,7 +4,7 @@ final class AphrontTableView extends AphrontView {
 
   protected $data;
   protected $headers;
-  protected $shortHeaders;
+  protected $shortHeaders = array();
   protected $rowClasses = array();
   protected $columnClasses = array();
   protected $cellClasses = array();
@@ -21,7 +21,7 @@ final class AphrontTableView extends AphrontView {
   protected $sortParam;
   protected $sortSelected;
   protected $sortReverse;
-  protected $sortValues;
+  protected $sortValues = array();
   private $deviceReadyTable;
 
   public function __construct(array $data) {

--- a/webroot/rsrc/externals/javelin/core/init_node.js
+++ b/webroot/rsrc/externals/javelin/core/init_node.js
@@ -49,7 +49,7 @@ JX.require = function(thing) {
   }
 
   vm.createScript(content, path)
-    .runInNewContext(sandbox, path);
+    .runInNewContext(sandbox);
 };
 
 exports.JX = JX;


### PR DESCRIPTION
Summary:
Ref T13222. See PHI996. Ref T10743. For context, perhaps see T12171.

Node changed some signatures, behaviors, and error handling here in recent versions. As far as I can tell:

  - The `script.runInNewContext(...)` method has never taken a `path` parameter, and passing the path has always been wrong.
  - The `script.runInNewContext(...)` method started taking an `[options]` parameter at some point, and validating it, so the bad `path` parameter now throws.
  - `vm.createScript(...)` is "soft deprecated" but basically fine, and keeping it looks more compatible.

This seems like the smallest and most compatible correct change.

Test Plan: Under Node 10, started Aphlict. Before: fatal error on bad `options` parameter to `runInNewContext()` (expected dictionary). After: notification server starts.

Reviewers: amckinley

Reviewed By: amckinley

Maniphest Tasks: T13222, T10743

Differential Revision: https://secure.phabricator.com/D19860

(cherry picked from commit 55a1ef339f4534ab1a8e1a0f82818f78f3408fab)

https://phabricator.endlessm.com/T31396